### PR TITLE
Prototype pollution fix - Checking magic attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import {
   isObject, isArray, isSet, isMap, isType,
-  typeError,
+  typeError, isPrototypePolluted,
 } from './util';
 
 // merge value to a target
@@ -36,6 +36,7 @@ const mergeObject = (...objects) => {
     }
 
     return Reflect.ownKeys(object).reduce((merged, key) => {
+      if (isPrototypePolluted(key)) return merged;
       merged[key] = mergeProperty(merged[key], object[key]);
       return merged;
     }, collection);

--- a/src/util.js
+++ b/src/util.js
@@ -35,3 +35,11 @@ export const formatType = (type) => {
 
 // throw a type error
 export const typeError = (value, type) => new Error(`Type-Error: ${value} is not an instance of ${formatType(type)}`);
+
+
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key key for check, string.
+ */
+export const isPrototypePolluted = (key) => ['__proto__', 'prototype', 'constructor'].includes(key);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,6 +27,15 @@ describe(`merge <Object/Array>`, () => {
     expect(merge(target, compare, compare2)).to.eql(result);
   });
 
+  it('should prevent prototype pollution', () => {
+    const obj = { placeholder: true };
+    const malicious = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}, "test": "t"}');
+    const result = merge(obj, malicious);
+    expect(result.polluted).to.equal(undefined);
+    expect({}.polluted).to.equal(undefined);
+    expect(result.polluted).to.not.equal("Yes! Its Polluted");
+  })
+
   // TODO - fix the circular problem
   /*it('[ loop calling ]', () => {
     let   target  = { name: 'shook' },


### PR DESCRIPTION
### 📊 Metadata *

@brikcss/merge is vulnerable to Prototype Pollution.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40brikcss%2Fmerge/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
var merge = require("@brikcss/merge")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = { placeholder: true }
console.log("Before : " + {}.polluted);
merge(obj, payload);
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i @brikcss/merge # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/105012119-c945f780-5a63-11eb-868f-b9baa8bed5ad.png)

After:
![image](https://user-images.githubusercontent.com/64132745/105008548-65b9cb00-5a5f-11eb-90cb-583fce47cb4e.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/105012870-a36d2280-5a64-11eb-9337-9c99a2171016.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1417